### PR TITLE
feat(downloader): album/playlist/Liked Songs batch download (Experimental)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
@@ -66,6 +67,12 @@
             android:exported="false"
             android:foregroundServiceType="mediaPlayback"
             tools:targetApi="28" />
+
+        <service
+            android:name=".service.DownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            tools:targetApi="34" />
 
         <receiver
             android:name="androidx.media.session.MediaButtonReceiver"

--- a/app/src/main/java/com/project/lol/bridge/SpotifyBridge.kt
+++ b/app/src/main/java/com/project/lol/bridge/SpotifyBridge.kt
@@ -11,6 +11,7 @@ import java.lang.ref.WeakReference
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.Locale
+import com.project.lol.offline.DownloadManager
 
 class SpotifyBridge(activityRef: WeakReference<Activity>) {
 
@@ -37,6 +38,7 @@ class SpotifyBridge(activityRef: WeakReference<Activity>) {
     var onEnterPipRequest: (() -> Unit)? = null
     var onEnterPipVideoRequest: ((Int, Int) -> Unit)? = null
     var onDownloadTrack: ((String) -> Unit)? = null
+    var onDownloadCollection: ((String) -> Unit)? = null
 
     @JavascriptInterface
     fun loginDetected() {
@@ -168,6 +170,25 @@ class SpotifyBridge(activityRef: WeakReference<Activity>) {
         json?.let { onDownloadTrack?.invoke(it) }
     }
 
+    @Suppress("unused")
+    @JavascriptInterface
+    fun downloadCollection(json: String?) {
+        json?.let { onDownloadCollection?.invoke(it) }
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun skipDownload() {
+        DownloadManager.skipCurrent()
+    }
+
+    @Suppress("unused")
+    @JavascriptInterface
+    fun cancelDownload() {
+        DownloadManager.cancelAll()
+    }
+
+    @Suppress("unused")
     @JavascriptInterface
     fun nFetch(url: String, optsJson: String?): String {
         val errorResult = { e: Exception ->

--- a/app/src/main/java/com/project/lol/offline/DownloadManager.kt
+++ b/app/src/main/java/com/project/lol/offline/DownloadManager.kt
@@ -234,6 +234,11 @@ object DownloadManager {
     }
 
     private suspend fun runSingle(appContext: Context, track: TrackMeta) {
+        if (OfflineStore.isTrackSaved(appContext, track.trackId)) {
+            onProgress?.invoke(100, "Already saved")
+            withContext(Dispatchers.Main) { onStatus?.invoke("Already saved to Music/Spotilol") }
+            return
+        }
         activeTrackId = track.trackId
         try {
             val result = runCatching {

--- a/app/src/main/java/com/project/lol/offline/DownloadManager.kt
+++ b/app/src/main/java/com/project/lol/offline/DownloadManager.kt
@@ -115,7 +115,10 @@ object DownloadManager {
     fun cancelAll() {
         signal = ControlSignal.CANCEL
         var dropped = 0
-        while (jobs.tryReceive().isSuccess) dropped++
+        while (jobs.tryReceive().isSuccess) {
+            pendingJobs.decrementAndGet()
+            dropped++
+        }
         Log.i(TAG, "cancelAll: cancel requested, dropped $dropped queued job(s)")
     }
 

--- a/app/src/main/java/com/project/lol/offline/DownloadManager.kt
+++ b/app/src/main/java/com/project/lol/offline/DownloadManager.kt
@@ -16,8 +16,20 @@ import com.project.lol.yt.YTPlayerUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import kotlin.time.Duration.Companion.milliseconds
+
+private data class TrackMeta(
+    val trackId: String,
+    val title: String,
+    val artist: String,
+    val album: String,
+    val cover: String?,
+)
 
 private data class DownloadedTrack(
     val success: Boolean,
@@ -26,13 +38,30 @@ private data class DownloadedTrack(
     val album: String,
 )
 
+private sealed class TrackResult {
+    data class Saved(val title: String, val artist: String, val album: String) : TrackResult()
+    data class Failed(val title: String, val artist: String, val album: String) : TrackResult()
+    object Aborted : TrackResult()
+}
+
 private data class ResolvedStream(
     val url: String,
     val chosen: SongItem,
 )
 
+private sealed class DownloadJob {
+    data class Single(val track: TrackMeta) : DownloadJob()
+    data class Collection(
+        val name: String,
+        val cover: String?,
+        val tracks: List<TrackMeta>,
+    ) : DownloadJob()
+}
+
 object DownloadManager {
     private const val TAG = "Spl-DL"
+    private const val BATCH_INTER_TRACK_DELAY_MS = 300L
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     @Volatile
@@ -44,9 +73,63 @@ object DownloadManager {
     @Volatile
     private var activeTrackId: String? = null
 
+    @Volatile
+    private var batchActive = false
+
+    private val jobs = Channel<DownloadJob>(Channel.UNLIMITED)
+
+    @Volatile
+    private var consumerStarted = false
+    private val consumerLock = Any()
+
+    @Volatile
+    var onProgress2: ((Int, String) -> Unit)? = null
+
+    @Volatile
+    var lastPct: Int = 0
+
+    @Volatile
+    var lastLabel: String = ""
+
+    private val pendingJobs = java.util.concurrent.atomic.AtomicInteger(0)
+
+    fun isWorkPending(): Boolean = pendingJobs.get() > 0
+
+    private fun progress(pct: Int, label: String) {
+        lastPct = pct
+        lastLabel = label
+        onProgress?.invoke(pct, label)
+        onProgress2?.invoke(pct, label)
+    }
+
+    private enum class ControlSignal { SKIP, CANCEL }
+
+    @Volatile
+    private var signal: ControlSignal? = null
+
+    fun skipCurrent() {
+        signal = ControlSignal.SKIP
+        Log.i(TAG, "skipCurrent: skip requested (active=${activeTrackId ?: "none"})")
+    }
+
+    fun cancelAll() {
+        signal = ControlSignal.CANCEL
+        var dropped = 0
+        while (jobs.tryReceive().isSuccess) dropped++
+        Log.i(TAG, "cancelAll: cancel requested, dropped $dropped queued job(s)")
+    }
+
+    private fun consumeSignal(): ControlSignal? {
+        val s = signal
+        signal = null
+        return s
+    }
+
     fun isDownloading(): Boolean = activeTrackId != null
 
     fun currentTrackId(): String? = activeTrackId
+
+    fun isBatchActive(): Boolean = batchActive
 
     fun downloadCurrentTrack(
         context: Context,
@@ -63,60 +146,259 @@ object DownloadManager {
             onStatus?.invoke("Could not identify the current track")
             return
         }
-        if (activeTrackId != null) {
-            Log.w(TAG, "downloadCurrentTrack: download already in progress ($activeTrackId), rejecting $trackId")
-            onStatus?.invoke("Please wait — a download is already in progress")
+        if (trackId == activeTrackId) {
+            Log.w(TAG, "downloadCurrentTrack: $trackId is already in progress")
+            onStatus?.invoke("This track is already downloading")
             return
         }
-        activeTrackId = trackId
-
-        val title = parsed.optString("title")
-        val artist = parsed.optString("artist")
-        val album = parsed.optString("album")
-        val cover = parsed.optString("cover")
-        Log.d(TAG, "downloadCurrentTrack: start id=$trackId title=$title artist=$artist")
+        val track = TrackMeta(
+            trackId = trackId,
+            title = parsed.optString("title"),
+            artist = parsed.optString("artist"),
+            album = parsed.optString("album"),
+            cover = parsed.optString("cover").ifBlank { null },
+        )
+        Log.d(TAG, "downloadCurrentTrack: queued id=$trackId title=${track.title} artist=${track.artist}")
         onProgress?.invoke(0, "Resolving audio...")
+        enqueue(appContext, DownloadJob.Single(track))
+    }
 
-        scope.launch {
-            val result = runCatching { downloadToFile(appContext, trackId, title, artist, album) }
-                .onFailure { Log.e(TAG, "downloadCurrentTrack: exception: ${it.message}", it) }
-                .getOrDefault(DownloadedTrack(false, title, artist, album))
+    fun downloadCollection(
+        context: Context,
+        payload: String,
+    ) {
+        val appContext = context.applicationContext
+        val parsed = runCatching { JSONObject(payload) }.getOrNull() ?: run {
+            onStatus?.invoke("Invalid download request")
+            return
+        }
+        val tracksJson = parsed.optJSONArray("tracks") ?: run {
+            onStatus?.invoke("No tracks found")
+            return
+        }
+        val seen = HashSet<String>()
+        val tracks = ArrayList<TrackMeta>(tracksJson.length())
+        for (i in 0 until tracksJson.length()) {
+            val o = tracksJson.optJSONObject(i) ?: continue
+            val id = o.optString("trackId").trim()
+            if (id.isBlank() || !seen.add(id)) continue
+            tracks.add(
+                TrackMeta(
+                    trackId = id,
+                    title = o.optString("title"),
+                    artist = o.optString("artist"),
+                    album = o.optString("album"),
+                    cover = o.optString("cover").ifBlank { null },
+                )
+            )
+        }
+        if (tracks.isEmpty()) {
+            onStatus?.invoke("No downloadable tracks found")
+            return
+        }
+        val name = parsed.optString("name").ifBlank { "Collection" }
+        val collectionCover = parsed.optString("cover").ifBlank { null }
+        val batch = if (collectionCover != null) {
+            tracks.map { if (it.cover == null) it.copy(cover = collectionCover) else it }
+        } else tracks
+        Log.i(TAG, "downloadCollection: '$name' type=${parsed.optString("type")} tracks=${batch.size}")
+        onProgress?.invoke(0, "Queued ${batch.size} tracks — $name")
+        enqueue(appContext, DownloadJob.Collection(name, collectionCover, batch))
+    }
+
+    private fun enqueue(appContext: Context, job: DownloadJob) {
+        pendingJobs.incrementAndGet()
+        jobs.trySend(job)
+        synchronized(consumerLock) {
+            if (!consumerStarted) {
+                consumerStarted = true
+                scope.launch { consumeLoop(appContext) }
+            }
+        }
+    }
+
+    private suspend fun consumeLoop(appContext: Context) {
+        for (job in jobs) {
+            pendingJobs.decrementAndGet()
+            signal = null
+            runCatching {
+                when (job) {
+                    is DownloadJob.Single -> runSingle(appContext, job.track)
+                    is DownloadJob.Collection -> runCollection(appContext, job)
+                }
+            }.onFailure { Log.e(TAG, "consumeLoop: job failed: ${it.message}", it) }
+        }
+    }
+
+    private suspend fun runSingle(appContext: Context, track: TrackMeta) {
+        activeTrackId = track.trackId
+        try {
+            val result = runCatching {
+                downloadToFile(appContext, track) { pct, label -> onProgress?.invoke(pct, label) }
+            }.onFailure { Log.e(TAG, "runSingle: exception: ${it.message}", it) }
+                .getOrElse {
+                    if (signal != null) TrackResult.Aborted
+                    else TrackResult.Failed(track.title, track.artist, track.album)
+                }
+            Log.i(TAG, "runSingle: finished id=${track.trackId} result=${result::class.simpleName}")
+            when (result) {
+                is TrackResult.Saved -> {
+                    OfflineStore.saveMetadata(
+                        appContext, track.trackId, result.title, result.artist, result.album, track.cover,
+                    )
+                    onProgress?.invoke(100, "Saved to Music/Spotilol")
+                    withContext(Dispatchers.Main) { onStatus?.invoke("Saved to Music/Spotilol") }
+                }
+                is TrackResult.Failed -> {
+                    val msg = "Download failed: ${lastDownloadError ?: "unknown error"}"
+                    onProgress?.invoke(-1, msg)
+                    withContext(Dispatchers.Main) { onStatus?.invoke(msg) }
+                }
+                // Single track: skip and cancel both simply stop the download.
+                TrackResult.Aborted -> {
+                    consumeSignal()
+                    onProgress?.invoke(-1, "Cancelled")
+                    withContext(Dispatchers.Main) { onStatus?.invoke("Download cancelled") }
+                }
+            }
+        } finally {
             activeTrackId = null
-            Log.i(TAG, "downloadCurrentTrack: finished id=$trackId success=${result.success} error=${lastDownloadError}")
-            if (result.success) {
-                OfflineStore.saveMetadata(
-                    appContext,
-                    trackId,
-                    result.title,
-                    result.artist,
-                    result.album,
-                    cover.ifBlank { null }
-                )
-                onProgress?.invoke(100, "Saved to Music/Spotilol")
-            } else {
-                onProgress?.invoke(-1, "Download failed: ${lastDownloadError ?: "unknown error"}")
+        }
+    }
+
+
+    private suspend fun runCollection(appContext: Context, job: DownloadJob.Collection) {
+        val total = job.tracks.size
+        var saved = 0
+        var failed = 0
+        var skipped = 0
+        var cancelled = false
+        batchActive = true
+        Log.i(TAG, "runCollection: start '${job.name}' total=$total")
+
+        try {
+            for ((index, track) in job.tracks.withIndex()) {
+                val n = index + 1
+                val shortTitle = track.title.ifBlank { track.trackId }
+                val completed = saved + failed + skipped
+
+                fun overallPct(trackPct: Int): Int {
+                    val frac = if (trackPct in 0..100) trackPct / 100.0 else 0.0
+                    return ((completed + frac) * 100.0 / total).toInt().coerceIn(0, 100)
+                }
+
+                fun report(pct: Int, text: String) {
+                    onProgress?.invoke(overallPct(pct), "$n/$total · $shortTitle — $text")
+                }
+
+                // Skip/cancel tapped between tracks (e.g. during the
+                // inter-track delay): consume it before starting this one.
+                when (consumeSignal()) {
+                    ControlSignal.CANCEL -> {
+                        cancelled = true
+                        break
+                    }
+                    ControlSignal.SKIP -> {
+                        skipped++
+                        Log.i(TAG, "runCollection: user skipped ${track.trackId}")
+                        report(100, "Skipped")
+                        continue
+                    }
+                    null -> {}
+                }
+
+                if (OfflineStore.isTrackSaved(appContext, track.trackId)) {
+                    skipped++
+                    Log.d(TAG, "runCollection: ${track.trackId} already saved, skipping")
+                    report(100, "Already saved")
+                    continue
+                }
+
+                activeTrackId = track.trackId
+                // Report at track start so the batch flags reach the UI
+                // before the (non-interruptible) resolver runs.
+                report(0, "Resolving...")
+                try {
+                    val result = runCatching {
+                        downloadToFile(appContext, track) { pct, text -> report(pct, text) }
+                    }.onFailure { Log.e(TAG, "runCollection: ${track.trackId} exception: ${it.message}", it) }
+                        .getOrElse {
+                            if (signal != null) TrackResult.Aborted
+                            else TrackResult.Failed(track.title, track.artist, track.album)
+                        }
+
+                    when (result) {
+                        is TrackResult.Saved -> {
+                            saved++
+                            OfflineStore.saveMetadata(
+                                appContext, track.trackId, result.title, result.artist, result.album, track.cover,
+                            )
+                            report(100, "Saved")
+                        }
+                        is TrackResult.Failed -> {
+                            failed++
+                            Log.w(TAG, "runCollection: ${track.trackId} failed: $lastDownloadError")
+                            report(0, "Failed — skipping")
+                        }
+                        TrackResult.Aborted -> when (consumeSignal()) {
+                            ControlSignal.CANCEL -> cancelled = true
+                            // SKIP (or the tail of a cancel): drop this track, batch lives on.
+                            else -> {
+                                skipped++
+                                report(100, "Skipped")
+                            }
+                        }
+                    }
+                } finally {
+                    activeTrackId = null
+                }
+
+                if (cancelled) break
+                if (index < job.tracks.lastIndex) {
+                    delay(BATCH_INTER_TRACK_DELAY_MS.milliseconds)
+                }
             }
-            kotlinx.coroutines.withContext(Dispatchers.Main) {
-                onStatus?.invoke(
-                    if (result.success) "Saved to Music/Spotilol"
-                    else "Download failed: ${lastDownloadError ?: "unknown error"}"
-                )
-            }
+        } finally {
+            batchActive = false
+        }
+
+        val processed = saved + failed + skipped
+        val summary = buildString {
+            append(saved)
+            append(if (saved == 1) " track saved" else " tracks saved")
+            if (skipped > 0) append(", $skipped skipped")
+            if (failed > 0) append(", $failed failed")
+            if (cancelled) append(" — cancelled at $processed/$total")
+        }
+        Log.i(TAG, "runCollection: done '${job.name}' saved=$saved failed=$failed skipped=$skipped cancelled=$cancelled")
+        withContext(Dispatchers.Main) { onStatus?.invoke(summary) }
+        when {
+            cancelled -> onProgress?.invoke(-1, summary)
+            saved > 0 -> onProgress?.invoke(100, "$summary — Music/Spotilol")
+            failed > 0 -> onProgress?.invoke(-1, summary)
         }
     }
 
     private suspend fun downloadToFile(
         context: Context,
-        trackId: String,
-        title: String,
-        artist: String,
-        album: String,
-    ): DownloadedTrack {
+        track: TrackMeta,
+        progress: (Int, String) -> Unit,
+    ): TrackResult {
+        val trackId = track.trackId
+        val title = track.title
+        val artist = track.artist
+        val album = track.album
+
+        if (signal != null) return TrackResult.Aborted
+
         val resolved = resolveStream(context, trackId, title, artist, album) ?: run {
             Log.w(TAG, "downloadToFile: no stream source for $trackId")
             lastDownloadError = "Download source not available yet"
-            return DownloadedTrack(false, title, artist, album)
+            return TrackResult.Failed(title, artist, album)
         }
+        // Resolution takes a few seconds and is not interruptible - catch
+        // aborts requested during it here instead of downloading anyway.
+        if (signal != null) return TrackResult.Aborted
 
         val effectiveTitle = title.ifBlank { resolved.chosen.title }
         val effectiveArtist = artist.ifBlank {
@@ -126,27 +408,31 @@ object DownloadManager {
 
         val dir = java.io.File(context.filesDir, "downloads").apply { mkdirs() }
         val tmpFile = java.io.File(dir, "$trackId.part")
-        onProgress?.invoke(1, "Downloading audio...")
-        val downloaded = httpDownloadRanged(resolved.url, tmpFile) { pct ->
-            onProgress?.invoke(pct, "Downloading audio...")
-        }
+        progress(1, "Downloading audio...")
+        val downloaded = httpDownloadRanged(
+            resolved.url,
+            tmpFile,
+            { pct -> progress(pct, "Downloading audio...") },
+            { signal != null },
+        )
         if (!downloaded) {
-            Log.e(TAG, "downloadToFile: audio download failed: ${lastDownloadError}")
+            Log.e(TAG, "downloadToFile: audio download failed: $lastDownloadError")
             runCatching { tmpFile.delete() }
-            return DownloadedTrack(false, effectiveTitle, effectiveArtist, effectiveAlbum)
+            if (signal != null) return TrackResult.Aborted
+            return TrackResult.Failed(effectiveTitle, effectiveArtist, effectiveAlbum)
         }
         Log.d(TAG, "downloadToFile: audio downloaded size=${tmpFile.length()}")
-        onProgress?.invoke(99, "Saving...")
+        progress(99, "Saving...")
 
         val uri = saveToPublicMusic(context, trackId, effectiveTitle, effectiveArtist, tmpFile, "m4a", "audio/mp4")
         tmpFile.delete()
         if (uri != null) {
             Log.d(TAG, "downloadToFile: saved to Music/Spotilol uri=$uri")
-            return DownloadedTrack(true, effectiveTitle, effectiveArtist, effectiveAlbum)
+            return TrackResult.Saved(effectiveTitle, effectiveArtist, effectiveAlbum)
         }
         Log.w(TAG, "downloadToFile: MediaStore save failed")
         lastDownloadError = "Couldn't save file"
-        return DownloadedTrack(false, effectiveTitle, effectiveArtist, effectiveAlbum)
+        return TrackResult.Failed(effectiveTitle, effectiveArtist, effectiveAlbum)
     }
 
     private suspend fun resolveStream(
@@ -218,17 +504,22 @@ object DownloadManager {
     @Volatile
     private var lastDownloadError: String? = null
 
-    private fun httpDownloadRanged(url: String, tmpFile: java.io.File, onProgress: ((Int) -> Unit)? = null): Boolean {
+    private fun httpDownloadRanged(url: String, tmpFile: java.io.File, onProgress: ((Int) -> Unit)? = null, shouldAbort: (() -> Boolean)? = null): Boolean {
         val chunk = 8L * 1024 * 1024
         var total = -1L
         var position = 0L
         return try {
             java.io.BufferedOutputStream(tmpFile.outputStream()).use { output ->
                 outer@ while (true) {
+                    if (shouldAbort?.invoke() == true) {
+                        Log.i(TAG, "httpDownloadRanged: aborted at $position bytes")
+                        return false
+                    }
                     val end = if (total > 0) minOf(position + chunk - 1, total - 1) else position + chunk - 1
                     var attempt = 0
                     var fullBody = false
                     while (true) {
+                        if (shouldAbort?.invoke() == true) return false
                         attempt++
                         val conn = openDownloadConn(url)
                         conn.setRequestProperty("Range", "bytes=$position-$end")
@@ -251,6 +542,10 @@ object DownloadManager {
                                 while (true) {
                                     val r = input.read(buf)
                                     if (r < 0) break
+                                    if (shouldAbort != null && shouldAbort()) {
+                                        Log.i(TAG, "httpDownloadRanged: aborted mid-chunk at $position")
+                                        return false
+                                    }
                                     output.write(buf, 0, r)
                                     position += r
                                     if (total > 0) {
@@ -262,6 +557,7 @@ object DownloadManager {
                             if (total > 0) Log.d(TAG, "httpDownloadRanged: chunk done $position/$total")
                             break
                         } catch (e: Exception) {
+                            if (shouldAbort?.invoke() == true) return false
                             Log.w(TAG, "httpDownloadRanged: chunk @$position failed attempt $attempt: ${e.message}")
                             if (attempt >= 4) {
                                 lastDownloadError = e.message ?: "Connection reset"

--- a/app/src/main/java/com/project/lol/offline/OfflineStore.kt
+++ b/app/src/main/java/com/project/lol/offline/OfflineStore.kt
@@ -180,4 +180,38 @@ object OfflineStore {
         removeMetadata(context, song.id)
         return ok
     }
+
+    /**
+     * TRUE if a track with this Spotify ID is already saved in Music/Spotilol.
+     * Used to de-duplicate album/playlist batch downloads. MediaStore is the
+     * source of truth on Q+; the folder listing on older devices.
+     */
+    fun isTrackSaved(context: Context, trackId: String): Boolean {
+        if (trackId.isBlank()) return false
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val escaped = trackId
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_")
+            runCatching {
+                context.contentResolver.query(
+                    MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL),
+                    arrayOf(MediaStore.Audio.Media._ID),
+                    "${MediaStore.Audio.Media.RELATIVE_PATH} LIKE ? AND " +
+                            "${MediaStore.Audio.Media.DISPLAY_NAME} LIKE ? ESCAPE '\\'",
+                    arrayOf("%Music/$FOLDER%", "%[$escaped]%"),
+                    null,
+                )?.use { it.count > 0 } ?: false
+            }.getOrDefault(false)
+        } else {
+            val dir = File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC),
+                FOLDER,
+            )
+            val marker = "[$trackId]."
+            runCatching {
+                dir.listFiles()?.any { it.isFile && it.name.contains(marker) } == true
+            }.getOrDefault(false)
+        }
+    }
 }

--- a/app/src/main/java/com/project/lol/service/DownloadService.kt
+++ b/app/src/main/java/com/project/lol/service/DownloadService.kt
@@ -1,0 +1,140 @@
+package com.project.lol.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.graphics.toColorInt
+import com.project.lol.R
+import com.project.lol.offline.DownloadManager
+import java.io.File
+
+class DownloadService : Service() {
+
+    companion object {
+        private const val CHANNEL_ID = "spotilol_downloads"
+        private const val NOTIF_ID = 3
+
+        const val ACTION_SKIP = "com.project.lol.download.ACTION_SKIP"
+        const val ACTION_CANCEL = "com.project.lol.download.ACTION_CANCEL"
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    private val pollRunnable = object : Runnable {
+        override fun run() {
+            if (!DownloadManager.isDownloading() && !DownloadManager.isWorkPending()) {
+                stopSelf()
+                return
+            }
+            updateNotification()
+            handler.postDelayed(this, 1000)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+        runCatching {
+            val dir = File(filesDir, "downloads")
+            if (dir.exists()) dir.listFiles()?.forEach { if (it.name.endsWith(".part")) it.delete() }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_SKIP -> DownloadManager.skipCurrent()
+            ACTION_CANCEL -> DownloadManager.cancelAll()
+        }
+        try {
+            ServiceCompat.startForeground(
+                this, NOTIF_ID, buildNotification(), foregroundServiceType()
+            )
+        } catch (e: Throwable) {
+            android.util.Log.e("DownloadService", "startForeground failed", e)
+        }
+        handler.removeCallbacks(pollRunnable)
+        handler.post(pollRunnable)
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        handler.removeCallbacks(pollRunnable)
+        super.onDestroy()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun foregroundServiceType(): Int =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        } else 0
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Downloads",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Spotilol track downloads"
+                setShowBadge(false)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            }
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+    }
+
+    private fun updateNotification() {
+        getSystemService(NotificationManager::class.java).notify(NOTIF_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
+        val pct = DownloadManager.lastPct
+        val label = DownloadManager.lastLabel.ifBlank { "Preparing download..." }
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Spotilol Download")
+            .setContentText(label)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setProgress(100, pct.coerceIn(0, 100), pct < 0)
+            .addAction(0, "Skip", actionPendingIntent(ACTION_SKIP))
+            .addAction(0, "Cancel", actionPendingIntent(ACTION_CANCEL))
+
+        try {
+            builder.color = com.project.lol.webview.helpers.AccentTheme
+                .resolveHex(this).toColorIntOrNull() ?: 0xFF1DB954.toInt()
+        } catch (_: Exception) {
+            builder.color = 0xFF1DB954.toInt()
+        }
+        return builder.build()
+    }
+
+    private fun actionPendingIntent(action: String): PendingIntent {
+        val intent = Intent(this, DownloadService::class.java).setAction(action)
+        return PendingIntent.getService(
+            this, action.hashCode(), intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}
+
+private fun String.toColorIntOrNull(): Int? = try {
+    toColorInt()
+} catch (_: IllegalArgumentException) {
+    null
+}

--- a/app/src/main/java/com/project/lol/service/DownloadService.kt
+++ b/app/src/main/java/com/project/lol/service/DownloadService.kt
@@ -32,7 +32,10 @@ class DownloadService : Service() {
 
     private val pollRunnable = object : Runnable {
         override fun run() {
-            if (!DownloadManager.isDownloading() && !DownloadManager.isWorkPending()) {
+            if (!DownloadManager.isDownloading() &&
+                !DownloadManager.isWorkPending() &&
+                !DownloadManager.isBatchActive()
+            ) {
                 stopSelf()
                 return
             }

--- a/app/src/main/java/com/project/lol/ui/MainActivity.kt
+++ b/app/src/main/java/com/project/lol/ui/MainActivity.kt
@@ -396,18 +396,16 @@ class MainActivity : ComponentActivity() {
 
                             bridge.onDownloadTrack = { payload ->
                                 Log.d("Spl-DL", "bridge.onDownloadTrack: payload=$payload")
-                                DownloadManager.onStatus = { msg ->
-                                    runOnUiThread {
-                                        Toast.makeText(this@MainActivity, msg, Toast.LENGTH_LONG).show()
-                                    }
-                                }
-                                DownloadManager.onProgress = { pct, label ->
-                                    runOnUiThread {
-                                        val safe = label.replace("\\", "\\\\").replace("'", "\\'").replace("\n", " ")
-                                        webView?.evaluateJavascript("window.splDownloadProgress($pct, '$safe')", null)
-                                    }
-                                }
+                                wireDownloadCallbacks()
+                                startDownloadService()
                                 DownloadManager.downloadCurrentTrack(this@MainActivity, payload)
+                            }
+
+                            bridge.onDownloadCollection = { payload ->
+                                Log.d("Spl-DL", "bridge.onDownloadCollection: payload=${payload.take(300)}")
+                                wireDownloadCallbacks()
+                                startDownloadService()
+                                DownloadManager.downloadCollection(this@MainActivity, payload)
                             }
 
 
@@ -1189,6 +1187,32 @@ class MainActivity : ComponentActivity() {
                 try { conn?.disconnect() } catch (_: Exception) {}
             }
         }.start()
+    }
+
+    private fun wireDownloadCallbacks() {
+        DownloadManager.onStatus = { msg ->
+            runOnUiThread {
+                Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
+            }
+        }
+        DownloadManager.onProgress = { pct, label ->
+            runOnUiThread {
+                val safe = label.replace("\\", "\\\\").replace("'", "\\'").replace("\n", " ")
+                val batch = DownloadManager.isBatchActive()
+                webView?.evaluateJavascript(
+                    "window.__splDlBatch=$batch;window.splDownloadProgress($pct, '$safe')",
+                    null
+                )
+            }
+        }
+    }
+
+    private fun startDownloadService() {
+        runCatching {
+            ContextCompat.startForegroundService(
+                this, Intent(this, com.project.lol.service.DownloadService::class.java)
+            )
+        }
     }
 
     private fun destroyWebView() {

--- a/app/src/main/java/com/project/lol/webview/SpotifyWebViewClient.kt
+++ b/app/src/main/java/com/project/lol/webview/SpotifyWebViewClient.kt
@@ -250,6 +250,7 @@ class SpotifyWebViewClient(
             append(DownloadButton.CONTENT)
             append(DownloadProgress.CONTENT)
             append(CollectionDownload.CONTENT)
+            append(ContextMenuDownload.CONTENT)
             append("""
                 (function(){
                     var recAcc=function(){

--- a/app/src/main/java/com/project/lol/webview/SpotifyWebViewClient.kt
+++ b/app/src/main/java/com/project/lol/webview/SpotifyWebViewClient.kt
@@ -249,6 +249,7 @@ class SpotifyWebViewClient(
             append(SearchOverlay.CONTENT)
             append(DownloadButton.CONTENT)
             append(DownloadProgress.CONTENT)
+            append(CollectionDownload.CONTENT)
             append("""
                 (function(){
                     var recAcc=function(){

--- a/app/src/main/java/com/project/lol/webview/injections/CollectionDownload.kt
+++ b/app/src/main/java/com/project/lol/webview/injections/CollectionDownload.kt
@@ -6,18 +6,23 @@ object CollectionDownload {
             if (window.__splColDlInit) return;
             window.__splColDlInit = true;
         
-            var SVG_DL = '<svg viewBox="0 0 16 16" width="24" height="24"><path fill="currentColor" d="M8 1a1 1 0 0 1 1 1v6.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L7 8.586V2a1 1 0 0 1 1-1zM2 13a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1z"/></svg>';
             var SVG_SKIP = '<svg viewBox="0 0 16 16" width="24" height="24"><path fill="currentColor" d="M3.3 1a.7.7 0 0 1 .7.7v5.15l9.95-5.744a.7.7 0 0 1 1.05.606v12.575a.7.7 0 0 1-1.05.607L4 9.149V14.3a.7.7 0 0 1-.7.7H1.7a.7.7 0 0 1-.7-.7V1.7a.7.7 0 0 1 .7-.7h1.6z"/></svg>';
             var SVG_X = '<svg viewBox="0 0 16 16" width="24" height="24"><path fill="currentColor" d="M2.47 2.47a.75.75 0 0 1 1.06 0L8 6.94l4.47-4.47a.75.75 0 1 1 1.06 1.06L9.06 8l4.47 4.47a.75.75 0 1 1-1.06 1.06L8 9.06l-4.47 4.47a.75.75 0 0 1-1.06-1.06L6.94 8 2.47 3.53a.75.75 0 0 1 0-1.06z"/></svg>';
         
+            var DL_LABELS = ['download','unduh','télécharger','descargar','herunterladen','scaricare','baixar','pobierz','загрузить','ダウンロード','다운로드','下载','下載'];
+            var CIRCLE_HEAD = 'M12 3a9 9 0';
+            var ARROW_HEAD = 'M12 6.05';
+        
             var ROW_SEL = 'div[data-testid="tracklist-row"]';
             var RECO_SEL = '.playlistRecommenderContainer, [data-testid="recommended-track"]';
+            var BAR_SEL = 'div[data-testid="action-bar-row"]';
+            var COVER_RE = /ab67616d0000[0-9a-f]{4}/i;
         
             function pageType(){
                 var p = location.pathname;
-                if (/\/playlist\//.test(p)) return 'playlist';
-                if (/\/album\//.test(p)) return 'album';
-                if (/collection\/tracks/.test(p)) return 'liked';
+                if (p.indexOf('/playlist/') !== -1) return 'playlist';
+                if (p.indexOf('/album/') !== -1) return 'album';
+                if (p.indexOf('/collection/tracks') !== -1) return 'liked';
                 return null;
             }
         
@@ -39,17 +44,6 @@ object CollectionDownload {
                 return null;
             }
         
-            function rowEls(){
-                var g = mainGrid();
-                if (g) return g.querySelectorAll(ROW_SEL);
-                var rows = document.querySelectorAll(ROW_SEL);
-                var out = [];
-                for (var i = 0; i < rows.length; i++) {
-                    if (!inRecommendations(rows[i])) out.push(rows[i]);
-                }
-                return out;
-            }
-        
             function findScroller(from){
                 var el = from;
                 while (el && el !== document.body) {
@@ -57,6 +51,11 @@ object CollectionDownload {
                     el = el.parentElement;
                 }
                 return null;
+            }
+        
+            function upCover(url){
+                if (!url) return '';
+                return url.replace(COVER_RE, 'ab67616d0000b273');
             }
         
             function findCover(){
@@ -77,7 +76,7 @@ object CollectionDownload {
                         if (els[i].src) { c = els[i].src; break; }
                     }
                 }
-                return c;
+                return upCover(c);
             }
         
             function headerName(fallback){
@@ -109,11 +108,13 @@ object CollectionDownload {
             }
         
             function scrape(albumFallback, grid){
-                var rows = grid ? grid.querySelectorAll(ROW_SEL) : rowEls();
+                var root = grid || document;
+                var rows = root.querySelectorAll(ROW_SEL);
+                var checkReco = !!root.querySelector(RECO_SEL);
                 var seen = {}, out = [];
                 for (var i = 0; i < rows.length; i++) {
                     var row = rows[i];
-                    if (inRecommendations(row)) continue;
+                    if (checkReco && inRecommendations(row)) continue;
                     var link = row.querySelector('a[data-testid="internal-track-link"]');
                     if (!link) continue;
                     var href = link.getAttribute('href') || '';
@@ -131,45 +132,94 @@ object CollectionDownload {
                     var al = row.querySelector('a[href*="/album/"]');
                     var album = albumFallback || (al ? (al.textContent || '').trim() : '');
                     var img = row.querySelector('img');
-                    var cover = (img && img.src) ? img.src : '';
+                    var cover = (img && img.src) ? upCover(img.src) : '';
                     out.push({ trackId: id, title: title, artist: arts.join(', '), album: album, cover: cover });
                 }
                 return out;
             }
         
             function busy(){
-                var b = document.getElementById('spl-dlall-btn');
-                return !!(b && b.classList.contains('spl-busy'));
+                return !!window.__splColBusy;
             }
         
-            function onDownloadAll(){
+            function onNativeDownload(e){
+                e.preventDefault();
+                e.stopPropagation();
                 if (busy()) return;
+                window.__splColBusy = true;
+                var btn = e.currentTarget;
+                if (btn) btn.classList.add('spl-ab-busy');
                 var type = pageType();
-                if (!type) return;
+                if (!type) { window.__splColBusy = false; if (btn) btn.classList.remove('spl-ab-busy'); return; }
                 var name = headerName(type === 'liked' ? 'Liked Songs' : 'Collection');
                 var albumFallback = (type === 'album') ? name : '';
-                var btn = document.getElementById('spl-dlall-btn');
-                if (btn) btn.classList.add('spl-busy');
                 try {
                     if (typeof window.splDownloadProgress === 'function') {
                         window.splDownloadProgress(0, 'Loading tracklist...');
                     }
-                } catch(e){}
+                } catch(e2){}
                 loadAll(function(grid){
                     var tracks = scrape(albumFallback, grid);
-                    if (btn) btn.classList.remove('spl-busy');
+                    window.__splColBusy = false;
+                    if (btn) btn.classList.remove('spl-ab-busy');
                     if (!tracks.length) {
-                        try { AndBridge.deferMessage('No downloadable tracks found'); } catch(e){}
+                        try { AndBridge.deferMessage('No downloadable tracks found'); } catch(e3){}
                         return;
                     }
                     var payload = { type: type, name: name, cover: findCover(), tracks: tracks };
                     try {
                         AndBridge.downloadCollection(JSON.stringify(payload));
-                    } catch(e) {
+                    } catch(e4) {
                         AndBridge.deferMessage('Download failed');
                     }
                 });
             }
+        
+            function isDownloadButton(b){
+                if (b.hasAttribute('aria-haspopup')) return false;
+                var al = (b.getAttribute('aria-label') || '').trim().toLowerCase();
+                if (al && DL_LABELS.indexOf(al) !== -1) return true;
+                var paths = b.querySelectorAll('svg path');
+                if (paths.length >= 2){
+                    var d1 = paths[0].getAttribute('d') || '';
+                    var d2 = paths[1].getAttribute('d') || '';
+                    if (d1.indexOf(CIRCLE_HEAD) === 0 && d2.indexOf(ARROW_HEAD) === 0) return true;
+                }
+                return false;
+            }
+        
+            function hijack(){
+                if (window.__splBg) return;
+                var bars = document.querySelectorAll(BAR_SEL);
+                for (var i = 0; i < bars.length; i++) {
+                    var btns = bars[i].querySelectorAll('button');
+                    for (var j = 0; j < btns.length; j++) {
+                        var b = btns[j];
+                        if (b.__splDlHijack) continue;
+                        if (!isDownloadButton(b)) continue;
+                        b.__splDlHijack = true;
+                        b.addEventListener('click', onNativeDownload, true);
+                    }
+                }
+            }
+        
+            var hijackPending = false;
+            var obs = new MutationObserver(function(muts){
+                if (window.__splBg) return;
+                var dirty = false;
+                for (var i = 0; i < muts.length && !dirty; i++) {
+                    if (muts[i].addedNodes.length > 0) dirty = true;
+                }
+                if (dirty && !hijackPending) {
+                    hijackPending = true;
+                    setTimeout(function(){ hijackPending = false; hijack(); }, 150);
+                }
+            });
+            function startObserver(){
+                try { obs.observe(document.body, { childList: true, subtree: true }); } catch(e){}
+            }
+            if (document.body) startObserver();
+            else document.addEventListener('DOMContentLoaded', startObserver);
         
             function makeBtn(id, label, svg, handler){
                 var b = document.createElement('button');
@@ -178,7 +228,7 @@ object CollectionDownload {
                 b.title = label;
                 b.setAttribute('aria-label', label);
                 b.innerHTML = svg;
-                if (id !== 'spl-dlall-btn') b.style.display = 'none';
+                b.style.display = 'none';
                 b.addEventListener('click', function(e){
                     e.stopPropagation();
                     try { handler(); } catch(err){}
@@ -186,14 +236,11 @@ object CollectionDownload {
                 return b;
             }
         
-            function ensureButton(){
+            function ensureButtons(){
                 var type = pageType();
                 if (!type) return;
-                var bar = document.querySelector('div[data-testid=action-bar-row]');
+                var bar = document.querySelector(BAR_SEL);
                 if (!bar) return;
-                if (!document.getElementById('spl-dlall-btn')) {
-                    bar.appendChild(makeBtn('spl-dlall-btn', 'Download all tracks', SVG_DL, onDownloadAll));
-                }
                 if (type === 'playlist' && !document.getElementById('spl-dl-skip-btn')) {
                     bar.appendChild(makeBtn('spl-dl-skip-btn', 'Skip current download', SVG_SKIP, function(){
                         AndBridge.skipDownload();
@@ -218,12 +265,12 @@ object CollectionDownload {
             var st = document.createElement('style');
             st.id = 'spl-dlall-style';
             st.textContent = [
-                '#spl-dlall-btn,#spl-dl-skip-btn,#spl-dl-cancel-btn{display:inline-flex;align-items:center;justify-content:center;width:48px;height:48px;background:transparent;border:none;border-radius:50%;color:#b3b3b3;cursor:pointer;padding:0;margin:0 0 0 4px;flex-shrink:0;-webkit-tap-highlight-color:transparent;transition:color .2s,transform .1s}',
-                '#spl-dlall-btn:hover,#spl-dl-skip-btn:hover{color:#fff;transform:scale(1.05)}',
+                '#spl-dl-skip-btn,#spl-dl-cancel-btn{display:inline-flex;align-items:center;justify-content:center;width:48px;height:48px;background:transparent;border:none;border-radius:50%;color:#b3b3b3;cursor:pointer;padding:0;margin:0 0 0 4px;flex-shrink:0;-webkit-tap-highlight-color:transparent;transition:color .2s,transform .1s}',
+                '#spl-dl-skip-btn:hover{color:#fff;transform:scale(1.05)}',
                 '#spl-dl-cancel-btn:hover{color:#e57373;transform:scale(1.05)}',
-                '#spl-dlall-btn:active,#spl-dl-skip-btn:active,#spl-dl-cancel-btn:active{transform:scale(.94)}',
-                '#spl-dlall-btn svg,#spl-dl-skip-btn svg,#spl-dl-cancel-btn svg{width:26px;height:26px;pointer-events:none}',
-                '#spl-dlall-btn.spl-busy{color:var(--spl-accent,#1DB954);pointer-events:none;animation:splDlAllPulse 1.2s ease-in-out infinite}',
+                '#spl-dl-skip-btn:active,#spl-dl-cancel-btn:active{transform:scale(.94)}',
+                '#spl-dl-skip-btn svg,#spl-dl-cancel-btn svg{width:26px;height:26px;pointer-events:none}',
+                'button.spl-ab-busy{pointer-events:none;animation:splDlAllPulse 1.2s ease-in-out infinite}',
                 '@keyframes splDlAllPulse{0%,100%{opacity:.5}50%{opacity:1}}'
             ].join('');
             function appendStyle(){
@@ -231,17 +278,18 @@ object CollectionDownload {
                 if (t && !document.getElementById('spl-dlall-style')) t.appendChild(st);
             }
             try { appendStyle(); } catch(e){}
-            document.addEventListener('DOMContentLoaded', appendStyle);
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', appendStyle);
+            }
         
-            setInterval(function(){
+            function tick(){
                 if (window.__splBg) return;
+                hijack();
+                ensureButtons();
                 syncButtons();
-            }, 500);
-            setInterval(function(){
-                if (window.__splBg) return;
-                ensureButton();
-            }, 2000);
-            ensureButton();
+            }
+            setInterval(tick, 2000);
+            tick();
         })();
     """
 }

--- a/app/src/main/java/com/project/lol/webview/injections/CollectionDownload.kt
+++ b/app/src/main/java/com/project/lol/webview/injections/CollectionDownload.kt
@@ -1,0 +1,247 @@
+package com.project.lol.webview.injections
+
+object CollectionDownload {
+    const val CONTENT = """
+        (function(){
+            if (window.__splColDlInit) return;
+            window.__splColDlInit = true;
+        
+            var SVG_DL = '<svg viewBox="0 0 16 16" width="24" height="24"><path fill="currentColor" d="M8 1a1 1 0 0 1 1 1v6.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L7 8.586V2a1 1 0 0 1 1-1zM2 13a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1z"/></svg>';
+            var SVG_SKIP = '<svg viewBox="0 0 16 16" width="24" height="24"><path fill="currentColor" d="M3.3 1a.7.7 0 0 1 .7.7v5.15l9.95-5.744a.7.7 0 0 1 1.05.606v12.575a.7.7 0 0 1-1.05.607L4 9.149V14.3a.7.7 0 0 1-.7.7H1.7a.7.7 0 0 1-.7-.7V1.7a.7.7 0 0 1 .7-.7h1.6z"/></svg>';
+            var SVG_X = '<svg viewBox="0 0 16 16" width="24" height="24"><path fill="currentColor" d="M2.47 2.47a.75.75 0 0 1 1.06 0L8 6.94l4.47-4.47a.75.75 0 1 1 1.06 1.06L9.06 8l4.47 4.47a.75.75 0 1 1-1.06 1.06L8 9.06l-4.47 4.47a.75.75 0 0 1-1.06-1.06L6.94 8 2.47 3.53a.75.75 0 0 1 0-1.06z"/></svg>';
+        
+            var ROW_SEL = 'div[data-testid="tracklist-row"]';
+            var RECO_SEL = '.playlistRecommenderContainer, [data-testid="recommended-track"]';
+        
+            function pageType(){
+                var p = location.pathname;
+                if (/\/playlist\//.test(p)) return 'playlist';
+                if (/\/album\//.test(p)) return 'album';
+                if (/collection\/tracks/.test(p)) return 'liked';
+                return null;
+            }
+        
+            function inRecommendations(el){
+                try { return !!(el.closest && el.closest(RECO_SEL)); } catch(e){ return false; }
+            }
+        
+            function mainGrid(){
+                var g = document.querySelector('div[data-testid="playlist-tracklist"]');
+                if (g && !inRecommendations(g)) return g;
+                var grids = document.querySelectorAll('div[role="grid"][aria-rowcount]');
+                for (var i = 0; i < grids.length; i++) {
+                    if (inRecommendations(grids[i])) continue;
+                    var rc = parseInt(grids[i].getAttribute('aria-rowcount') || '0', 10);
+                    if (rc > 0 && grids[i].querySelector(ROW_SEL)) {
+                        return grids[i];
+                    }
+                }
+                return null;
+            }
+        
+            function rowEls(){
+                var g = mainGrid();
+                if (g) return g.querySelectorAll(ROW_SEL);
+                var rows = document.querySelectorAll(ROW_SEL);
+                var out = [];
+                for (var i = 0; i < rows.length; i++) {
+                    if (!inRecommendations(rows[i])) out.push(rows[i]);
+                }
+                return out;
+            }
+        
+            function findScroller(from){
+                var el = from;
+                while (el && el !== document.body) {
+                    if (el.scrollHeight > el.clientHeight + 100) return el;
+                    el = el.parentElement;
+                }
+                return null;
+            }
+        
+            function findCover(){
+                var c = '';
+                try {
+                    var og = document.querySelector('meta[property="og:image"]');
+                    if (og) c = og.getAttribute('content') || '';
+                } catch(e){}
+                if (!c) {
+                    var els = document.querySelectorAll(
+                        'div[data-testid="cover-art-image"],' +
+                        'div[data-testid="entity-image"],' +
+                        'div[data-testid="entity-image"] img,' +
+                        'section[data-testid="album-page"] img,' +
+                        'section[data-testid="playlist-page"] img'
+                    );
+                    for (var i = 0; i < els.length; i++) {
+                        if (els[i].src) { c = els[i].src; break; }
+                    }
+                }
+                return c;
+            }
+        
+            function headerName(fallback){
+                var h1 = document.querySelector('main h1');
+                var n = (h1 && h1.textContent || '').trim();
+                return n || fallback;
+            }
+        
+            function loadAll(cb){
+                var tl = mainGrid();
+                if (!tl) { cb(null); return; }
+                var sc = findScroller(tl);
+                var top = sc ? sc.scrollTop : 0;
+                var target = parseInt(tl.getAttribute('aria-rowcount') || '0', 10) || 0;
+                var last = -1, stable = 0, iter = 0;
+                var iv = setInterval(function(){
+                    iter++;
+                    if (sc) { try { sc.scrollTop = sc.scrollHeight; } catch(e){} }
+                    try { window.dispatchEvent(new Event('scroll')); } catch(e){}
+                    var c = tl.querySelectorAll(ROW_SEL).length;
+                    if (c === last) stable++; else stable = 0;
+                    last = c;
+                    if ((target > 0 && c >= target - 1) || stable >= 5 || iter >= 90) {
+                        clearInterval(iv);
+                        if (sc) { try { sc.scrollTop = top; } catch(e){} }
+                        setTimeout(function(){ cb(tl); }, 300);
+                    }
+                }, 250);
+            }
+        
+            function scrape(albumFallback, grid){
+                var rows = grid ? grid.querySelectorAll(ROW_SEL) : rowEls();
+                var seen = {}, out = [];
+                for (var i = 0; i < rows.length; i++) {
+                    var row = rows[i];
+                    if (inRecommendations(row)) continue;
+                    var link = row.querySelector('a[data-testid="internal-track-link"]');
+                    if (!link) continue;
+                    var href = link.getAttribute('href') || '';
+                    var id = href.split('/track/')[1];
+                    if (id) id = id.split('?')[0].split('#')[0];
+                    if (!id || seen[id]) continue;
+                    seen[id] = true;
+                    var title = (link.textContent || '').trim();
+                    var arts = [];
+                    var links = row.querySelectorAll('a[href*="/artist/"]');
+                    for (var j = 0; j < links.length; j++) {
+                        var t = (links[j].textContent || '').trim();
+                        if (t) arts.push(t);
+                    }
+                    var al = row.querySelector('a[href*="/album/"]');
+                    var album = albumFallback || (al ? (al.textContent || '').trim() : '');
+                    var img = row.querySelector('img');
+                    var cover = (img && img.src) ? img.src : '';
+                    out.push({ trackId: id, title: title, artist: arts.join(', '), album: album, cover: cover });
+                }
+                return out;
+            }
+        
+            function busy(){
+                var b = document.getElementById('spl-dlall-btn');
+                return !!(b && b.classList.contains('spl-busy'));
+            }
+        
+            function onDownloadAll(){
+                if (busy()) return;
+                var type = pageType();
+                if (!type) return;
+                var name = headerName(type === 'liked' ? 'Liked Songs' : 'Collection');
+                var albumFallback = (type === 'album') ? name : '';
+                var btn = document.getElementById('spl-dlall-btn');
+                if (btn) btn.classList.add('spl-busy');
+                try {
+                    if (typeof window.splDownloadProgress === 'function') {
+                        window.splDownloadProgress(0, 'Loading tracklist...');
+                    }
+                } catch(e){}
+                loadAll(function(grid){
+                    var tracks = scrape(albumFallback, grid);
+                    if (btn) btn.classList.remove('spl-busy');
+                    if (!tracks.length) {
+                        try { AndBridge.deferMessage('No downloadable tracks found'); } catch(e){}
+                        return;
+                    }
+                    var payload = { type: type, name: name, cover: findCover(), tracks: tracks };
+                    try {
+                        AndBridge.downloadCollection(JSON.stringify(payload));
+                    } catch(e) {
+                        AndBridge.deferMessage('Download failed');
+                    }
+                });
+            }
+        
+            function makeBtn(id, label, svg, handler){
+                var b = document.createElement('button');
+                b.id = id;
+                b.type = 'button';
+                b.title = label;
+                b.setAttribute('aria-label', label);
+                b.innerHTML = svg;
+                if (id !== 'spl-dlall-btn') b.style.display = 'none';
+                b.addEventListener('click', function(e){
+                    e.stopPropagation();
+                    try { handler(); } catch(err){}
+                });
+                return b;
+            }
+        
+            function ensureButton(){
+                var type = pageType();
+                if (!type) return;
+                var bar = document.querySelector('div[data-testid=action-bar-row]');
+                if (!bar) return;
+                if (!document.getElementById('spl-dlall-btn')) {
+                    bar.appendChild(makeBtn('spl-dlall-btn', 'Download all tracks', SVG_DL, onDownloadAll));
+                }
+                if (type === 'playlist' && !document.getElementById('spl-dl-skip-btn')) {
+                    bar.appendChild(makeBtn('spl-dl-skip-btn', 'Skip current download', SVG_SKIP, function(){
+                        AndBridge.skipDownload();
+                    }));
+                }
+                if (!document.getElementById('spl-dl-cancel-btn')) {
+                    bar.appendChild(makeBtn('spl-dl-cancel-btn', 'Cancel download', SVG_X, function(){
+                        AndBridge.cancelDownload();
+                    }));
+                }
+            }
+        
+            function syncButtons(){
+                var act = !!window.__splDlActive;
+                var batch = act && !!window.__splDlBatch;
+                var sk = document.getElementById('spl-dl-skip-btn');
+                var ca = document.getElementById('spl-dl-cancel-btn');
+                if (sk) sk.style.display = batch ? 'inline-flex' : 'none';
+                if (ca) ca.style.display = act ? 'inline-flex' : 'none';
+            }
+        
+            var st = document.createElement('style');
+            st.id = 'spl-dlall-style';
+            st.textContent = [
+                '#spl-dlall-btn,#spl-dl-skip-btn,#spl-dl-cancel-btn{display:inline-flex;align-items:center;justify-content:center;width:48px;height:48px;background:transparent;border:none;border-radius:50%;color:#b3b3b3;cursor:pointer;padding:0;margin:0 0 0 4px;flex-shrink:0;-webkit-tap-highlight-color:transparent;transition:color .2s,transform .1s}',
+                '#spl-dlall-btn:hover,#spl-dl-skip-btn:hover{color:#fff;transform:scale(1.05)}',
+                '#spl-dl-cancel-btn:hover{color:#e57373;transform:scale(1.05)}',
+                '#spl-dlall-btn:active,#spl-dl-skip-btn:active,#spl-dl-cancel-btn:active{transform:scale(.94)}',
+                '#spl-dlall-btn svg,#spl-dl-skip-btn svg,#spl-dl-cancel-btn svg{width:26px;height:26px;pointer-events:none}',
+                '#spl-dlall-btn.spl-busy{color:var(--spl-accent,#1DB954);pointer-events:none;animation:splDlAllPulse 1.2s ease-in-out infinite}',
+                '@keyframes splDlAllPulse{0%,100%{opacity:.5}50%{opacity:1}}'
+            ].join('');
+            function appendStyle(){
+                var t = document.head || document.documentElement;
+                if (t && !document.getElementById('spl-dlall-style')) t.appendChild(st);
+            }
+            try { appendStyle(); } catch(e){}
+            document.addEventListener('DOMContentLoaded', appendStyle);
+        
+            setInterval(function(){
+                if (window.__splBg) return;
+                syncButtons();
+            }, 500);
+            setInterval(function(){
+                if (window.__splBg) return;
+                ensureButton();
+            }, 2000);
+            ensureButton();
+        })();
+    """
+}

--- a/app/src/main/java/com/project/lol/webview/injections/ContextMenuDownload.kt
+++ b/app/src/main/java/com/project/lol/webview/injections/ContextMenuDownload.kt
@@ -1,0 +1,248 @@
+package com.project.lol.webview.injections
+
+/*
+ * CREDIT: Spotilol - Context Menu Download
+ *
+ * Adds a "Download" item to Spotify's track context menu (the "..."
+ * button on a tracklist row, or right-click on the row itself).
+ *
+ * - The track (id/title/artists/album/cover) is harvested from the row
+ *   DOM at menu-open time via capture-phase listeners on contextmenu
+ *   and menu-trigger clicks. Non-track menus (album/playlist headers,
+ *   page background) reset the capture, so a stale track can never
+ *   leak into the wrong menu.
+ * - The item is built by cloning an existing plain menu entry at
+ *   runtime, so hashed Encore classes, hover styling and icon sizing
+ *   survive Spotify deploys. Only the icon path (the player's download
+ *   glyph) and the label text are swapped.
+ * - Clicking it hands the payload to AndBridge.downloadTrack - the
+ *   exact same pipeline as the player's download button - then closes
+ *   the menu with a synthesized Escape keydown (tippy-root detach as
+ *   last-resort fallback).
+ * - Injection runs from a MutationObserver (menu arriving in the DOM)
+ *   plus a mouseover safety net that re-injects if a React re-render
+ *   wipes the item mid-session. Visibility filtering skips the stale
+ *   hidden context menus tippy leaves lying around in the DOM.
+ */
+
+object ContextMenuDownload {
+    const val CONTENT = """
+        (function(){
+            if(window.__splCtxDlInit) return;
+            window.__splCtxDlInit = true;
+        
+            var DL_ICON = 'M8 1a1 1 0 0 1 1 1v6.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L7 8.586V2a1 1 0 0 1 1-1zM2 13a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1z';
+        
+            window.__splMenuTrack = null;
+
+            function splUpCover(url){
+                if(!url) return '';
+                return url.replace(/ab67616d0000[0-9a-f]{4}/i, 'ab67616d0000b273');
+            }
+        
+            function splGrabRowTrack(row){
+                if(!row) return null;
+                var link = row.querySelector('a[data-testid="internal-track-link"]') ||
+                           row.querySelector('a[href*="/track/"]');
+                if(!link) return null;
+                var m = (link.getAttribute('href')||'').match(/\/track\/([A-Za-z0-9]+)/);
+                if(!m || !m[1]) return null;
+                var artists = [];
+                var arts = row.querySelectorAll('a[href*="/artist/"]');
+                for(var i=0;i<arts.length;i++){
+                    var nm = (arts[i].textContent||'').trim();
+                    if(nm && artists.indexOf(nm) === -1) artists.push(nm);
+                }
+                var al = row.querySelector('a[href*="/album/"]');
+                var img = row.querySelector('img');
+                return {
+                    trackId: m[1],
+                    title: (link.textContent||'').trim(),
+                    artist: artists.join(', '),
+                    album: al ? (al.textContent||'').trim() : '',
+                    cover: img ? splUpCover(img.src||'') : ''
+                };
+            }
+        
+            function splActiveMenu(){
+                var menus = document.querySelectorAll('[data-testid="context-menu"]');
+                for(var i=0;i<menus.length;i++){
+                    var el = menus[i];
+                    var r = el.getBoundingClientRect();
+                    if(r.width < 2 || r.height < 2) continue;
+                    var cs;
+                    try{ cs = getComputedStyle(el); }catch(e){ continue; }
+                    if(cs.visibility === 'hidden' || parseFloat(cs.opacity) < 0.02) continue;
+                    return el;
+                }
+                return null;
+            }
+        
+            function splDoMenuDownload(track){
+                if(!track || !track.trackId){
+                    try{ AndBridge.deferMessage('Track not ready'); }catch(e){}
+                    return;
+                }
+                try{
+                    AndBridge.downloadTrack(JSON.stringify({
+                        trackId: track.trackId,
+                        title: track.title || '',
+                        artist: track.artist || '',
+                        album: track.album || '',
+                        cover: track.cover || ''
+                    }));
+                }catch(e){}
+            }
+        
+            function splCloseMenu(){
+                try{
+                    var root = splActiveMenu();
+                    var ul = root ? root.querySelector('ul[role="menu"]') : null;
+                    if(ul){
+                        ul.dispatchEvent(new KeyboardEvent('keydown', {
+                            key: 'Escape', code: 'Escape',
+                            keyCode: 27, which: 27,
+                            bubbles: true, cancelable: true
+                        }));
+                    }
+                }catch(e){}
+                setTimeout(function(){
+                    try{
+                        var m = splActiveMenu();
+                        if(m){
+                            var tr = m.closest('[data-tippy-root]') || m.parentElement;
+                            if(tr && tr.parentElement) tr.remove();
+                        }
+                    }catch(e){}
+                }, 250);
+            }
+        
+            function splInjectItem(ul, track){
+                var src = null;
+                var lis = ul.querySelectorAll('li[role="presentation"]');
+                for(var i=0;i<lis.length;i++){
+                    var li = lis[i];
+                    if(li.classList.contains('spl-menu-dl')) continue;
+                    var b = li.querySelector('button[role="menuitem"]');
+                    if(!b) continue;
+                    if(b.hasAttribute('aria-expanded')) continue;
+                    if(li.querySelector('img')) continue;
+                    src = li;
+                    break;
+                }
+                if(!src) return false;
+        
+                var clone = src.cloneNode(true);
+                clone.classList.add('spl-menu-dl');
+        
+                var btn = clone.querySelector('button[role="menuitem"]');
+                btn.removeAttribute('id');
+                btn.setAttribute('aria-label', 'Download');
+        
+                var svg = clone.querySelector('svg[data-encore-id="icon"]');
+                if(svg){
+                    while(svg.firstChild) svg.removeChild(svg.firstChild);
+                    var p = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+                    p.setAttribute('d', DL_ICON);
+                    svg.appendChild(p);
+                }
+        
+                var spans = clone.querySelectorAll('span[data-encore-id]');
+                if(spans.length){
+                    spans[0].textContent = 'Download';
+                } else {
+                    var f = clone.querySelector('span');
+                    if(f) f.textContent = 'Download';
+                }
+        
+                btn.addEventListener('click', function(e){
+                    e.preventDefault();
+                    e.stopPropagation();
+                    splDoMenuDownload(track);
+                    splCloseMenu();
+                }, true);
+        
+                ul.insertBefore(clone, ul.firstChild);
+                return true;
+            }
+        
+            function splTryInject(attempt){
+                if(attempt > 25) return;
+                if(window.__splBg) return;
+                var t = window.__splMenuTrack;
+                if(!t || !t.trackId) return;
+                var root = splActiveMenu();
+                var ul = root ? root.querySelector('ul[role="menu"]') : null;
+                if(!ul){
+                    setTimeout(function(){ splTryInject(attempt+1); }, 120);
+                    return;
+                }
+                if(ul.querySelector('.spl-menu-dl')) return;
+                if(!splInjectItem(ul, t)){
+                    setTimeout(function(){ splTryInject(attempt+1); }, 120);
+                }
+            }
+        
+            function splCaptureFromEvent(e){
+                var row = null;
+                try{
+                    if(e.target && e.target.closest){
+                        row = e.target.closest('div[data-testid="tracklist-row"]');
+                    }
+                }catch(err){}
+                window.__splMenuTrack = splGrabRowTrack(row);
+            }
+        
+            document.addEventListener('contextmenu', splCaptureFromEvent, true);
+        
+            document.addEventListener('click', function(e){
+                var trig = null;
+                try{
+                    if(e.target && e.target.closest){
+                        trig = e.target.closest('[aria-haspopup="menu"]');
+                    }
+                }catch(err){}
+                if(!trig) return;
+                splCaptureFromEvent(e);
+            }, true);
+        
+            var obsPending = false;
+            var obs = new MutationObserver(function(muts){
+                if(window.__splBg) return;
+                var hit = false;
+                for(var i=0;i<muts.length && !hit;i++){
+                    var a = muts[i].addedNodes;
+                    for(var j=0;j<a.length;j++){
+                        var n = a[j];
+                        if(n.nodeType !== 1) continue;
+                        if(n.id === 'context-menu' ||
+                           n.getAttribute('data-testid') === 'context-menu' ||
+                           n.querySelector('[data-testid="context-menu"]')){
+                            hit = true;
+                            break;
+                        }
+                    }
+                }
+                if(hit && !obsPending){
+                    obsPending = true;
+                    setTimeout(function(){
+                        obsPending = false;
+                        splTryInject(0);
+                    }, 60);
+                }
+            });
+            obs.observe(document.body, { childList: true, subtree: true });
+        
+            var splLastHover = 0;
+            document.addEventListener('mouseover', function(e){
+                if(Date.now() - splLastHover < 150) return;
+                try{
+                    if(e.target && e.target.closest && e.target.closest('[data-testid="context-menu"]')){
+                        splLastHover = Date.now();
+                        splTryInject(0);
+                    }
+                }catch(err){}
+            }, true);
+        })();
+    """
+}

--- a/app/src/main/java/com/project/lol/webview/injections/DownloadProgress.kt
+++ b/app/src/main/java/com/project/lol/webview/injections/DownloadProgress.kt
@@ -2,68 +2,100 @@ package com.project.lol.webview.injections
 
 object DownloadProgress {
     const val CONTENT = """
-            (function(){
-                var dlEl = null;
-                var dlVisible = false;
-                var dlHideTimer = null;
-                function createEl(){
-                    var player = document.getElementById('spotilolPlayerControls');
-                    if(!player) return null;
-                    var el = document.createElement('div');
-                    el.id = 'spl-dl-progress';
-                    el.innerHTML = '<div id="spl-dl-label" style="color:#fff;font-size:11px;font-weight:600;font-family:-apple-system,Roboto,sans-serif;margin-bottom:5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"></div>' +
-                        '<div style="height:3px;background:rgba(255,255,255,0.14);border-radius:2px;overflow:hidden;"><div id="spl-dl-fill" style="height:100%;width:0%;background:#1DB954;border-radius:2px;transition:width 0.2s linear;"></div></div>';
-                    el.style.cssText = 'position:absolute;bottom:100%;left:0;right:0;margin-bottom:8px;background:rgba(24,24,24,0.97);border:1px solid rgba(255,255,255,0.1);border-radius:10px;box-shadow:0 6px 20px rgba(0,0,0,0.5);padding:8px 12px;opacity:0;transform:translateY(14px);transition:opacity 0.22s ease, transform 0.22s ease;pointer-events:none;display:none;z-index:1;';
-                    player.insertBefore(el, player.firstChild);
-                    return el;
-                }
-                function popIn(){
-                    if(!dlEl){
-                        dlEl = createEl();
-                        if(!dlEl) return;
-                    }
-                    dlEl.style.display = '';
-                    if(!dlVisible){
-                        dlVisible = true;
-                        requestAnimationFrame(function(){
-                            requestAnimationFrame(function(){
-                                dlEl.style.opacity = '1';
-                                dlEl.style.transform = 'translateY(0)';
-                            });
-                        });
-                    }
-                }
-                function popOut(){
-                    if(!dlEl || !dlVisible) return;
-                    dlVisible = false;
-                    dlEl.style.opacity = '0';
-                    dlEl.style.transform = 'translateY(14px)';
-                    clearTimeout(dlHideTimer);
-                    dlHideTimer = setTimeout(function(){ if(!dlVisible) dlEl.style.display = 'none'; }, 240);
-                }
-                window.splDownloadProgress = function(pct, label){
-                    if(!dlEl) dlEl = createEl();
-                    var labelEl = document.getElementById('spl-dl-label');
-                    var fillEl = document.getElementById('spl-dl-fill');
-                    if(labelEl) labelEl.textContent = label || '';
-                    clearTimeout(dlHideTimer);
-                    if(pct < 0){
-                        fillEl.style.width = '0%';
-                        fillEl.style.background = '#e57373';
-                        popIn();
-                        dlHideTimer = setTimeout(popOut, 4000);
-                    } else if(pct >= 100){
-                        fillEl.style.width = '100%';
-                        fillEl.style.background = '#1DB954';
-                        popIn();
-                        dlHideTimer = setTimeout(popOut, 2500);
-                    } else {
-                        fillEl.style.width = pct + '%';
-                        fillEl.style.background = '#1DB954';
-                        popIn();
-                    }
-                };
-            })();
+        (function () {
+            var ACCENT = 'var(--spl-accent,#1DB954)';
+            var ERROR_BG = '#e57373';
+            var BOX_CSS = 'background:rgba(24,24,24,0.97);border:1px solid rgba(255,255,255,0.1);border-radius:10px;box-shadow:0 6px 20px rgba(0,0,0,0.5);padding:8px 12px;opacity:0;transition:opacity 0.22s ease,transform 0.22s ease;pointer-events:none;display:none;';
         
+            var dlEl = null, labelEl = null, fillEl = null;
+            var dlVisible = false;
+            var dlHideTimer = null;
+            var dlFixed = false;
+        
+            function expandedPlayer() {
+                var p = document.getElementById('spotilolPlayerControls');
+                return (p && !p.classList.contains('spl-mini')) ? p : null;
+            }
+        
+            function baseTransform() {
+                return dlFixed ? 'translateX(-50%) ' : '';
+            }
+        
+            function createEl(player) {
+                var el = document.createElement('div');
+                el.id = 'spl-dl-progress';
+                el.innerHTML =
+                    '<div id="spl-dl-label" style="color:#fff;font-size:11px;font-weight:600;font-family:-apple-system,Roboto,sans-serif;margin-bottom:5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"></div>' +
+                    '<div style="height:3px;background:rgba(255,255,255,0.14);border-radius:2px;overflow:hidden;">' +
+                        '<div id="spl-dl-fill" style="height:100%;width:0%;background:' + ACCENT + ';border-radius:2px;transition:width 0.2s linear;"></div>' +
+                    '</div>';
+        
+                if (player) {
+                    dlFixed = false;
+                    el.style.cssText = BOX_CSS + 'position:absolute;bottom:100%;left:0;right:0;margin-bottom:8px;transform:translateY(14px);z-index:1;';
+                    player.insertBefore(el, player.firstChild);
+                } else {
+                    dlFixed = true;
+                    el.style.cssText = BOX_CSS + 'position:fixed;bottom:92px;left:50%;width:min(420px,calc(100vw - 32px));transform:translateX(-50%) translateY(14px);z-index:2147483647;';
+                    document.body.appendChild(el);
+                }
+        
+                labelEl = el.querySelector('#spl-dl-label');
+                fillEl = el.querySelector('#spl-dl-fill');
+                return el;
+            }
+        
+            function popIn() {
+                if (dlVisible) return;
+                dlVisible = true;
+                var el = dlEl;
+                el.style.display = '';
+                requestAnimationFrame(function () {
+                    requestAnimationFrame(function () {
+                        el.style.opacity = '1';
+                        el.style.transform = baseTransform() + 'translateY(0)';
+                    });
+                });
+            }
+        
+            function popOut() {
+                if (!dlEl || !dlVisible) return;
+                dlVisible = false;
+                dlEl.style.opacity = '0';
+                dlEl.style.transform = baseTransform() + 'translateY(14px)';
+                dlHideTimer = setTimeout(function () {
+                    if (!dlVisible) dlEl.style.display = 'none';
+                }, 240);
+            }
+        
+            window.splDownloadProgress = function (pct, label) {
+                var player = expandedPlayer();
+                var wantFixed = !player;
+        
+                if (dlEl && dlFixed !== wantFixed) {
+                    clearTimeout(dlHideTimer);
+                    dlEl.remove();
+                    dlEl = labelEl = fillEl = null;
+                    dlVisible = false;
+                }
+                if (!dlEl) dlEl = createEl(player);
+        
+                window.__splDlActive = (pct >= 0 && pct < 100);
+                labelEl.textContent = label || '';
+                clearTimeout(dlHideTimer);
+        
+                if (pct < 0) {
+                    fillEl.style.width = '0%';
+                    fillEl.style.background = ERROR_BG;
+                    popIn();
+                    dlHideTimer = setTimeout(popOut, 4000);
+                } else {
+                    fillEl.style.width = Math.min(pct, 100) + '%';
+                    fillEl.style.background = ACCENT;
+                    popIn();
+                    if (pct >= 100) dlHideTimer = setTimeout(popOut, 2500);
+                }
+            };
+        })();
     """
 }

--- a/app/src/main/java/com/project/lol/webview/injections/SpotilolPlayer.kt
+++ b/app/src/main/java/com/project/lol/webview/injections/SpotilolPlayer.kt
@@ -79,6 +79,7 @@ object SpotilolPlayer {
                     +'<button class="spl-btn spl-btn-sm" id="spl-lyrics" aria-label="Lyrics"><svg viewBox="0 0 16 16"><path fill="currentColor" d="M13.426 2.574a2.831 2.831 0 0 0-4.797 1.55l3.247 3.247a2.831 2.831 0 0 0 1.55-4.797M10.5 8.118l-2.619-2.62L4.74 9.075 2.065 12.12a1.287 1.287 0 0 0 1.816 1.816l3.06-2.688 3.56-3.129zM7.12 4.094a4.331 4.331 0 1 1 4.786 4.786l-3.974 3.493-3.06 2.689a2.787 2.787 0 0 1-3.933-3.933l2.676-3.045z"/></svg></button>'
                     +'<button class="spl-btn spl-btn-sm" id="spl-queue" aria-label="Queue"><svg viewBox="0 0 16 16"><path fill="currentColor" d="M15 15H1v-1.5h14zm0-4.5H1V9h14zm-14-7A2.5 2.5 0 0 1 3.5 1h9a2.5 2.5 0 0 1 0 5h-9A2.5 2.5 0 0 1 1 3.5m2.5-1a1 1 0 0 0 0 2h9a1 1 0 1 0 0-2z"/></svg></button>'
                     +'<button class="spl-btn spl-btn-sm" id="spl-download" aria-label="Download"><svg viewBox="0 0 16 16"><path fill="currentColor" d="M8 1a1 1 0 0 1 1 1v6.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 1 1 1.414-1.414L7 8.586V2a1 1 0 0 1 1-1zM2 13a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1z"/></svg></button>'
+                    +'<button class="spl-btn spl-btn-sm" id="spl-dl-cancel" aria-label="Cancel download" style="display:none;"><svg viewBox="0 0 16 16"><path fill="currentColor" d="M2.47 2.47a.75.75 0 0 1 1.06 0L8 6.94l4.47-4.47a.75.75 0 1 1 1.06 1.06L9.06 8l4.47 4.47a.75.75 0 1 1-1.06 1.06L8 9.06l-4.47 4.47a.75.75 0 0 1-1.06-1.06L6.94 8 2.47 3.53a.75.75 0 0 1 0-1.06z"/></svg></button>'
                     +'<div class="spl-vol-wrap" id="spl-vol">'
                     +'<button class="spl-btn spl-btn-sm spl-vol-btn" id="spl-vol-btn" aria-label="Volume"><svg viewBox="0 0 16 16"><path fill="currentColor" d="M9.741.85a.75.75 0 0 1 .375.65v13a.75.75 0 0 1-1.125.65l-6.925-4a3.64 3.64 0 0 1-1.33-4.967 3.64 3.64 0 0 1 1.33-1.332l6.925-4a.75.75 0 0 1 .75 0zm-6.924 5.3a2.14 2.14 0 0 0 0 3.7l5.8 3.35V2.8zm8.683 4.29V5.56a2.75 2.75 0 0 1 0 4.88"/><path fill="currentColor" d="M11.5 13.614a5.752 5.752 0 0 0 0-11.228v1.55a4.252 4.252 0 0 1 0 8.127z"/></svg></button>'
                     +'<div class="spl-vol-bar" id="spl-vol-bar"><div class="spl-vol-track"></div><div class="spl-vol-fill" id="spl-vol-fill"></div><div class="spl-vol-handle" id="spl-vol-handle"></div></div>'
@@ -157,6 +158,7 @@ object SpotilolPlayer {
                 };
                 document.getElementById('spl-liked').onclick=function(){actAddToFav()};
                 document.getElementById('spl-download').onclick=function(){splDoDownload()};
+                document.getElementById('spl-dl-cancel').onclick=function(){ try{ AndBridge.cancelDownload(); }catch(e){} };
 
                 var splTrack=document.getElementById('spl-track');
                 var splArtist=document.getElementById('spl-artist');
@@ -329,6 +331,8 @@ object SpotilolPlayer {
                             ly.style.display='none';
                         }
                         if(tm) tm.classList.toggle('spl-active',typeof sleepTimerActive!=='undefined'&&sleepTimerActive&&sleepTimerActive.value);
+                        var dcb=document.getElementById('spl-dl-cancel');
+                        if(dcb) dcb.style.display = window.__splDlActive ? '' : 'none';
 
                         var pbEl=document.querySelector('[data-testid="playback-progressbar"] [data-testid="progress-bar"]');
                         if(pbEl){


### PR DESCRIPTION
## Summary

Extends the downloader beyond single tracks: entire **albums, playlists, and the Liked Songs library** can now be saved to `Music/Spotilol` in one action, with skip/cancel controls and downloads that survive backgrounding.

Built as an **Experimental** feature on top of v1.1.1.

**10 files changed, +923 / −117 lines** — single clean commit.

## Features

- **"Download all" button** in the action bar row on album, playlist, and Liked Songs pages.
- **Batch progress** in the download overlay — overall `n/total` per track, with a saved/skipped/failed summary on completion.
- **Skip / Cancel controls** — in-app buttons (overlay, player, and collection pages) plus notification action buttons, all routed to the same control signals.
- **Background-safe downloads** — a new `dataSync` foreground service shields active downloads from process death (LMK) and Doze network restrictions.

## How it works

### Job queue (`DownloadManager`)

- The old `activeTrackId` guard is replaced with a serialized unbounded-Channel job queue and a single consumer coroutine. Single-track and batch requests share the same resolve → download → save pipeline, eliminating "download in progress" rejections and in-flight races.
- `downloadCollection()` parses the JS payload, deduplicates track IDs, and propagates collection cover art to rows scraped without one.
- The batch loop skips tracks already saved (`OfflineStore.isTrackSaved`), isolates per-track failures without aborting the whole run, and throttles the resolver with a 300 ms inter-track delay.

### Abort controls (skip / cancel)

- A volatile `ControlSignal` (`SKIP` / `CANCEL`) is checked at track boundaries, before/after stream resolution, and **per 64 KB buffer read** inside the ranged download loop — so skip responds almost instantly mid-transfer.
- `skipCurrent()` abandons the in-flight track and the batch continues with the next item; `cancelAll()` aborts the current track, drains the queue, and ends the batch with a "cancelled at n/total" summary.
- Stale signals are cleared when the consumer dequeues its next job, so an idle tap can never poison a future download.

### `CollectionDownload` injection

- Scroll-loads Spotify's virtualized tracklist until the main grid's DOM row count matches `aria-rowcount` (or stabilizes), restoring the original scroll position afterwards.
- Row discovery is scoped to the main tracklist grid with a per-row `closest()` exclusion as defense in depth — the "Recommended songs" section renders the same `tracklist-row` testid, and a document-wide query would end up downloading recommended tracks along with the playlist.
- Harvests per-row album-art thumbnails and `og:image` covers; skip/cancel buttons are synced to download state on a 500 ms poll.

### `DownloadService` (background protection)

- New `dataSync` foreground service mirrors batch progress in the notification (progress bar + Skip/Cancel actions routed to the same `DownloadManager` signals as the in-app buttons).
- Self-terminates via a 1 s poll once the queue drains; sweeps orphaned `.part` files from previous process deaths on create.
- Started on every download request (always a foreground user interaction), so FGS-from-background restrictions never apply.

## Fixes

- **Download overlay invisible when the player is minimized** — the overlay is positioned above the player (`bottom: 100%`), but `.spl-mini` sets `overflow: hidden`, silently clipping it. It now anchors to the viewport when the custom player is absent, in original-player mode, or minimized, and re-anchors automatically on mini ↔ expanded toggles detected at each progress event.
- **Player UI** — cancel button beside the player download button, toggled from the rAF update loop via the shared `__splDlActive` state.

## Notes

- Branch is based cleanly on `main` (v1.1.1) — single commit, no merge commits, no build-config changes.
- New `@JavascriptInterface` methods on `SpotifyBridge`: `downloadCollection` / `skipDownload` / `cancelDownload`, with matching callbacks; batch state is exposed to the page as `window.__splDlBatch`.
- Marked **Experimental** on purpose: the scroll-load heuristics depend on Spotify's DOM structure (`aria-rowcount`, `tracklist-row` testids) and may need periodic maintenance.
