### PR TITLE
feat(webview): add library panel auto-close on outside interaction

### DIFF
--- a/app/src/main/java/com/project/lol/webview/SpotifyWebViewClient.kt
+++ b/app/src/main/java/com/project/lol/webview/SpotifyWebViewClient.kt
@@ -289,6 +289,7 @@ class SpotifyWebViewClient(
             append(ToastFix.CONTENT)
             append(LyricsSyncFix.CONTENT)
             append(QueueAutoClose.CONTENT)
+            append(LibraryAutoClose.CONTENT)
             if (playerMode == "spotilol") {
                 append(SpotilolPlayer.CONTENT)
             }

--- a/app/src/main/java/com/project/lol/webview/injections/LibraryAutoClose.kt
+++ b/app/src/main/java/com/project/lol/webview/injections/LibraryAutoClose.kt
@@ -1,0 +1,152 @@
+package com.project.lol.webview.injections
+
+/*
+ * CREDIT: Spotilol - Library Auto-Close
+ *
+ * Closes the library whenever the user interacts with anything
+ * that isn't the library itself - same pattern as QueueAutoClose.
+ *
+ * Two library shapes are handled:
+ *  1. Native side panel "Your Library" (PanelHeader_CloseButton whose
+ *     header h1 reads "Your Library") - closed via its own close button.
+ *  2. CssHack expanded left sidebar (fullscreen overlay, zIndex 20) -
+ *     collapsed via the library toggle button (lBtn), the same click
+ *     switchLs listens to. Grid items keep their existing close-on-click
+ *     handler (lbit), so track picks still collapse + play.
+ *
+ * Nav links (Home/Search) inside the expanded sidebar also collapse it,
+ * since they navigate away and would otherwise leave the overlay
+ * stranded on top of the new page.
+ */
+
+object LibraryAutoClose {
+    const val CONTENT = """
+        (function () {
+            if (window.__splLibraryAutoClose) return;
+            window.__splLibraryAutoClose = true;
+        
+            var LIBRARY_SET = new Set(['your library','pustaka kamu','pustakamu','tu biblioteca','la tua libreria','deine mediathek','ваша библиотека','twoja biblioteka','sua biblioteca','votre bibliothèque','ta bibliothèque','jouw bibliotheek','ditt bibliotek','kitaplığın','ライブラリ','라이브러리']);
+            var CLOSE_SEL   = '[data-testid="PanelHeader_CloseButton"]';
+            var HIDDEN_SEL  = '[aria-hidden="true"]';
+            var IGNORE_SEL  = 'button[data-testid="library-button"], [role="menu"], [role="dialog"], [data-tippy-root]';
+            var SIDEBAR_SEL = '#Desktop_LeftSidebar_Id';
+            var SKIP_SEL    = HIDDEN_SEL + ', ' + SIDEBAR_SEL;
+        
+            var cache = null;
+        
+            function isLibraryHeader(h1) {
+                return LIBRARY_SET.has((h1.textContent || '').trim().toLowerCase());
+            }
+        
+            function findLibraryPanel() {
+                var btns = document.querySelectorAll(CLOSE_SEL);
+                if (!btns.length) return null;
+        
+                var mains = [], m;
+                if ((m = document.querySelector('main'))) mains.push(m);
+                if ((m = document.getElementById('main-view'))) mains.push(m);
+        
+                var h1s = document.querySelectorAll('h1'), libH1s = [];
+                for (var i = 0; i < h1s.length; i++) {
+                    if (isLibraryHeader(h1s[i])) libH1s.push(h1s[i]);
+                }
+                if (!libH1s.length) return null;
+        
+                function overMainScope(node) {
+                    for (var i = 0; i < mains.length; i++) {
+                        if (node !== mains[i] && node.contains(mains[i])) return true;
+                    }
+                    return false;
+                }
+        
+                for (var b = 0; b < btns.length; b++) {
+                    var btn = btns[b];
+                    if (btn.closest(SKIP_SEL)) continue;
+                    var r = btn.getBoundingClientRect();
+                    if (r.width < 2 || r.height < 2) continue;
+        
+                    var node = btn.parentElement, headerRoot = null;
+                    for (var h = 0; h < 8 && node && node !== document.body; h++, node = node.parentElement) {
+                        if (overMainScope(node)) break;
+                        for (var j = 0; j < libH1s.length; j++) {
+                            if (node.contains(libH1s[j])) { headerRoot = node; break; }
+                        }
+                        if (headerRoot) break;
+                    }
+                    if (!headerRoot) continue;
+        
+                    var panel = headerRoot, p = headerRoot.parentElement;
+                    while (p && p !== document.body && !overMainScope(p)) {
+                        panel = p;
+                        p = p.parentElement;
+                    }
+                    return { panel: panel, closeBtn: panel.querySelector(CLOSE_SEL + ' button') || btn };
+                }
+                return null;
+            }
+        
+            function getLibraryPanel() {
+                if (cache) {
+                    if (cache.panel.isConnected &&
+                        cache.closeBtn.isConnected &&
+                        !cache.closeBtn.closest(HIDDEN_SEL)) {
+                        var r = cache.closeBtn.getBoundingClientRect();
+                        if (r.width >= 2 && r.height >= 2) return cache;
+                    }
+                    cache = null;
+                }
+                return (cache = findLibraryPanel());
+            }
+        
+            function sidebarEl() {
+                return document.querySelector(SIDEBAR_SEL);
+            }
+        
+            function sidebarExpanded(ls) {
+                return ls.style.zIndex === '20' ||
+                       (ls.style.position === 'fixed' && ls.style.width === '100%');
+            }
+        
+            function collapseSidebar() {
+                var lb = window.lBtn, ls;
+                if (!lb && (ls = sidebarEl())) {
+                    lb = ls.querySelector('header>div>div:first-child button');
+                }
+                if (lb) { try { lb.click(); } catch (e) {} }
+            }
+        
+            function closeLibrary() {
+                var lib = getLibraryPanel();
+                if (lib) { try { lib.closeBtn.click(); } catch (e) {} }
+                var ls = sidebarEl();
+                if (ls && sidebarExpanded(ls)) collapseSidebar();
+            }
+        
+            document.addEventListener('click', function (e) {
+                if (window.__splBg || !e.isTrusted) return;
+                var t = e.target;
+                if (!t || !t.closest) return;
+                if (t.closest(IGNORE_SEL)) return;
+        
+                var ls = sidebarEl();
+        
+                var lib = getLibraryPanel();
+                if (lib && !lib.panel.contains(t)) {
+                    try { lib.closeBtn.click(); } catch (err) {}
+                }
+        
+                if (ls && sidebarExpanded(ls)) {
+                    var fold = !ls.contains(t) ||
+                               (!t.closest('div[role=grid]') &&
+                                t.closest(SIDEBAR_SEL + ' nav a[href]'));
+                    if (fold) setTimeout(collapseSidebar, 0);
+                }
+            }, true);
+        
+            window.addEventListener('popstate', function () {
+                if (window.__splBg) return;
+                closeLibrary();
+            });
+        })();
+    """
+}


### PR DESCRIPTION
Introduce LibraryAutoClose injection that automatically dismisses the "Your Library" view whenever the user interacts with any element outside of it, mirroring the existing QueueAutoClose behavior.

Motivation
----------
Users frequently open the library to browse or pick a track, then tap elsewhere (search, home, an artist link) expecting the panel to get out of the way. Previously it stayed open and had to be dismissed manually, which felt inconsistent next to the queue panel that already auto-closes under the same conditions.

Implementation
--------------
Two distinct library surfaces are handled:

1. Native side panel - detected via PanelHeader_CloseButton whose header <h1> matches a localized "Your Library" string set (en, id, es, it, de, ru, pl, pt, fr, nl, sv, tr, ja, ko). The surrounding panel scope is resolved by walking ancestors up to (but not past) the main view container, then closed via its own close button. The resolved panel is cached and re-validated on every click (connectivity + visibility + aria-hidden) to survive React re-renders.

2. CssHack expanded left sidebar - the fullscreen overlay applied by switchLs() (fixed position, 100% width, zIndex 20). Collapse is performed by clicking the library toggle button (lBtn), the exact same mechanism the grid-item handler and manual toggle already use, so state can never desync. Expanded state is read strictly from the inline styles switchLs() applies - never guessed from Spotify's internal nav state - ensuring a collapse click can never accidentally open the library instead.

Interaction rules:
- Trusted, capture-phase click listener (programmatic clicks and background state are ignored, preventing event loops).
- Clicks inside the library itself, the library toggle button, context menus, dialogs, and tippy tooltips are exempt.
- Grid items inside the expanded sidebar keep their existing close-on-click handler (lbit) and are not double-handled.
- Nav links (Home/Search) inside the sidebar collapse it behind the navigation so the overlay is never left stranded on the new page.
- Back/forward navigation (popstate) closes the library as well.

Wiring
------
Injected from SpotifyWebViewClient.injectPlayerControl(), appended immediately after QueueAutoClose so both auto-close behaviors ship together on every page load.

Verification
------------
- Open library (both sidebar and panel forms), tap search/home/ track/artist/album links -> library closes.
- Interact inside the library (scroll, grid items, menus) -> stays open.
- Toggle library open/close repeatedly -> no state flip, no loops.
- Library remains usable in all supported locales listed above.